### PR TITLE
Videoplayer Crash if no preferred tuner set

### DIFF
--- a/src/Info.cpp
+++ b/src/Info.cpp
@@ -40,15 +40,20 @@ Tuner* Info::GetPreferredTuner()
     std::set<uint32_t> ids;
 
     std::stringstream ss{g.Settings.preferredTuner};
-    while(ss.good())
+    if (ss.rdbuf()->in_avail() == 0) 
     {
-        std::string r;
-        getline(ss, r, ' ');
-        uint32_t id = std::stoul(r, 0, 16);
+        // No preferred tuner set
+    } else {    
+        while(ss.good())
+        {
+            std::string r;
+            getline(ss, r, ' ');
+            uint32_t id = std::stoul(r, 0, 16);
 
-        ids.insert(id);
+            ids.insert(id);
+        }
     }
-
+    
     for (;;) {
         Tuner* tuner = GetNextTuner();
 

--- a/src/Info.cpp
+++ b/src/Info.cpp
@@ -39,19 +39,18 @@ Tuner* Info::GetPreferredTuner()
 {
     std::set<uint32_t> ids;
 
-    std::stringstream ss{g.Settings.preferredTuner};
+    std::stringstream ss{g.Settings.preferredTuner};   
     if (ss.rdbuf()->in_avail() == 0) 
     {
-        // No preferred tuner set
-    } else {    
-        while(ss.good())
-        {
-            std::string r;
-            getline(ss, r, ' ');
-            uint32_t id = std::stoul(r, 0, 16);
+        return nullptr;
+    }
+    while(ss.good() && !ss.eof())
+    {
+        std::string r;
+        getline(ss, r, ' ');
+        uint32_t id = std::stoul(r, 0, 16);
 
-            ids.insert(id);
-        }
+        ids.insert(id);
     }
     
     for (;;) {


### PR DESCRIPTION
I came across this issue, when you havent set a preferred tuner in settings, the videoplayer will crash in the ss.good() loop. Ive just added check if preferred tuner is empty (none set) the function will continue on. Im not sure on the best way to continue, so feel free to provide any alternative solution.
With this change, the Videoplayer will start and run the channel as intended